### PR TITLE
Allow Naming of Columns

### DIFF
--- a/ballet/feature.py
+++ b/ballet/feature.py
@@ -282,10 +282,7 @@ class Feature:
             clsname=type(self).__name__, attrs_str=attrs_str)
 
     def as_input_transformer_tuple(self):
-        if self.name:
-            return (self.input, self.transformer, {'alias': self.name})
-        else:
-            return self.input, self.transformer
+        return (self.input, self.transformer, {'alias': self.output})
 
     def as_dataframe_mapper(self):
         return DataFrameMapper([

--- a/ballet/feature.py
+++ b/ballet/feature.py
@@ -282,7 +282,10 @@ class Feature:
             clsname=type(self).__name__, attrs_str=attrs_str)
 
     def as_input_transformer_tuple(self):
-        return self.input, self.transformer
+        if self.name:
+            return (self.input, self.transformer, {'alias': self.name})
+        else:
+            return self.input, self.transformer
 
     def as_dataframe_mapper(self):
         return DataFrameMapper([

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -159,7 +159,7 @@ class FeatureTest(unittest.TestCase):
         feature = Feature(self.input, self.transformer)
         tup = feature.as_input_transformer_tuple()
         self.assertIsInstance(tup, tuple)
-        self.assertEqual(len(tup), 2)
+        self.assertEqual(len(tup), 3)
 
     def test_feature_as_dataframe_mapper(self):
         feature = Feature(self.input, self.transformer)


### PR DESCRIPTION
Allows the Feature.name attribute to propagate to the column when used.

e.g the column(s) associated with Feature(name = 'calculated_feature' **kwargs) will have the 'calculated_feature' name.
