### PR TITLE
Feature equality

### DIFF
--- a/ballet/eng/base.py
+++ b/ballet/eng/base.py
@@ -26,6 +26,17 @@ class SimpleFunctionTransformer(BaseTransformer):
         self.func_kwargs = func_kwargs if func_kwargs else {}
         self.func_call = funcy.rpartial(
             self.func, *self.func_args, **self.func_kwargs)
+    
+    def __eq__(self, other):
+        if not isinstance(other, SimpleFunctionTransformer):
+            return False 
+        if self.func.__code__.co_code != other.func.__code__.co_code:
+            return False
+        if self.func_args != other.func_args:
+            return False
+        if self.func_kwargs != other.func_kwargs:
+            return False
+        return True
 
     def transform(self, X, **transform_kwargs):
         return self.func_call(X)
@@ -36,6 +47,15 @@ class GroupedFunctionTransformer(SimpleFunctionTransformer):
                  func_kwargs=None, groupby_kwargs=None):
         super().__init__(func, func_args=func_args, func_kwargs=func_kwargs)
         self.groupby_kwargs = groupby_kwargs if groupby_kwargs else {}
+    
+    def __eq__(self, other):
+        if not isinstance(other, GroupedFunctionTransformer):
+            return False
+        if not SimpleFunctionTransformer.__eq__(self, other):
+            return False
+        if self.groupby_kwargs != other.groupby_kwargs:
+            return False
+        return True
 
     def transform(self, X, **transform_kwargs):
         if self.groupby_kwargs:

--- a/ballet/eng/misc.py
+++ b/ballet/eng/misc.py
@@ -46,6 +46,16 @@ class BoxCoxTransformer(BaseTransformer):
         self.threshold = threshold
         self.lmbda = lmbda
 
+    def __eq__(self, other):
+        if not isinstance(other, BoxCoxTransformer):
+            return False
+        if self.threshold != other.threshold:
+            return False
+        if self.lmbda != other.lmbda:
+            return False
+        return True
+
+
     def fit(self, X, y=None, **fit_args):
         # features_to_transform_ is a bool or array[bool]
         self.features_to_transform_ = abs(skew(X)) > self.threshold

--- a/ballet/eng/misc.py
+++ b/ballet/eng/misc.py
@@ -11,6 +11,11 @@ __all__ = ['IdentityTransformer', 'ValueReplacer', 'NamedFramer']
 class IdentityTransformer(SimpleFunctionTransformer):
     def __init__(self):
         super().__init__(funcy.identity)
+    
+    def __eq__(self, other):
+        if not isinstance(other, IdentityTransformer):
+            return False
+        return True
 
 
 class ValueReplacer(BaseTransformer):
@@ -18,6 +23,15 @@ class ValueReplacer(BaseTransformer):
         super().__init__()
         self.value = value
         self.replacement = replacement
+
+    def __eq__(self, other):
+        if not isinstance(other, ValueReplacer):
+            return False
+        if self.value != other.value:
+            return False
+        if self.replacement != other.replacement:
+            return False
+        return True
 
     def transform(self, X, **transform_kwargs):
         X = X.copy()
@@ -30,6 +44,13 @@ class NamedFramer(BaseTransformer):
     def __init__(self, name):
         super().__init__()
         self.name = name
+    
+    def __eq__(self, other):
+        if not isinstance(other, NamedFramer):
+            return False
+        if self.name != other.name:
+            return False
+        return True
 
     def transform(self, X, **transform_kwargs):
         msg = "Couldn't convert object {} to named 1d DataFrame."

--- a/ballet/eng/missing.py
+++ b/ballet/eng/missing.py
@@ -12,6 +12,13 @@ class LagImputer(GroupedFunctionTransformer):
         super().__init__(lambda x: x.fillna(method='ffill'),
                          groupby_kwargs=groupby_kwargs)
 
+    def __eq__(self, other):
+        if not isinstance(other, LagImputer):
+            return False
+        if self.groupby_kwargs != other.groupby_kwargs:
+            return False
+        return True
+
 
 class NullFiller(BaseTransformer):
     """Fill values passing a filter with a given replacement
@@ -29,6 +36,15 @@ class NullFiller(BaseTransformer):
             self.isnull = isnull
         self.replacement = replacement
 
+    def __eq__(self, other):
+        if not isinstance(other, NullFiller):
+            return False
+        if self.isnull.__code__.co_code != other.isnull.__code__.co_code:
+            return False
+        if self.replacement != other.replacement:
+            return False
+        return True
+
     def transform(self, X, **transform_kwargs):
         X = X.copy()
         mask = self.isnull(X)
@@ -38,5 +54,10 @@ class NullFiller(BaseTransformer):
 
 class NullIndicator(BaseTransformer):
     """Indicate whether values are null or not"""
+    def __eq__(self, other):
+        if not isinstance(other, NullIndicator):
+            return False
+        return True
+
     def transform(self, X, **tranform_kwargs):
         return np.isnan(X).astype(int)

--- a/ballet/eng/ts.py
+++ b/ballet/eng/ts.py
@@ -14,11 +14,14 @@ class SingleLagger(GroupedFunctionTransformer):
     """
     def __init__(self, lag, groupby_kwargs=None):
         super().__init__(lambda x: x.shift(lag), groupby_kwargs=groupby_kwargs)
+        self.lag = lag
 
     def __eq__(self, other):
         if not isinstance(other, SingleLagger):
             return False
         if not GroupedFunctionTransformer.__eq__(self, other):
+            return False
+        if self.lag != other.lag:
             return False
         return True
 

--- a/ballet/eng/ts.py
+++ b/ballet/eng/ts.py
@@ -15,6 +15,13 @@ class SingleLagger(GroupedFunctionTransformer):
     def __init__(self, lag, groupby_kwargs=None):
         super().__init__(lambda x: x.shift(lag), groupby_kwargs=groupby_kwargs)
 
+    def __eq__(self, other):
+        if not isinstance(other, SingleLagger):
+            return False
+        if not GroupedFunctionTransformer.__eq__(self, other):
+            return False
+        return True
+
 
 def make_multi_lagger(lags, groupby_kwargs=None):
     """Return a union of transformers that apply different lags

--- a/ballet/feature.py
+++ b/ballet/feature.py
@@ -113,7 +113,7 @@ class DelegatingRobustTransformer(DeepcopyMixin, TransformerMixin):
             name=name, transformer=self._transformer)
     
     def __eq__(self, other):
-        if isinstance(other, DelegatingRobustTransformer):
+        if not isinstance(other, DelegatingRobustTransformer):
             return False
         if self._stored_conversion_approach != other._stored_conversion_approach:
             return False
@@ -305,6 +305,8 @@ class Feature:
             return False
         if self.name != other.name:
             return False
+        if self.input != other.input:
+            return False
         if self.description != other.description:
             return False
         if self.output != other.output:
@@ -319,7 +321,7 @@ class Feature:
                 return False
             if len(self.transformer.steps) != len(other.transformer.steps):
                 return False
-            for i in range(self.transformer.steps):
+            for i in range(len(self.transformer.steps)):
                 if self.transformer.steps[i] != other.transformer.steps[i]:
                     return False
         if self.options != other.options:

--- a/ballet/feature.py
+++ b/ballet/feature.py
@@ -111,6 +111,16 @@ class DelegatingRobustTransformer(DeepcopyMixin, TransformerMixin):
         name = type(self).__name__
         return '{name}({transformer!r})'.format(
             name=name, transformer=self._transformer)
+    
+    def __eq__(self, other):
+        if isinstance(other, DelegatingRobustTransformer):
+            return False
+        if self._stored_conversion_approach != other._stored_conversion_approach:
+            return False
+        if self._transformer != other._transformer:
+            return False 
+        return True
+
 
     @property
     def _tname(self):
@@ -265,9 +275,27 @@ class Feature:
 
         self.name = name
         self.description = description
-        self.output = output  # unused
+        self.output = output
         self.source = source
         self.options = options if options is not None else {}
+
+    def __eq__(self, other):
+        if not isinstance(other, Feature):
+            return False
+        if self.name != other.name:
+            return False
+        if self.description != other.description:
+            return False
+        if self.output != other.output:
+            return False 
+        if self.source != other.source:
+            return False
+        if self.transformer != other.transformer:
+            return False
+        if self.options != other.options:
+            return False 
+
+        return True
 
     def __repr__(self):
         # TODO use self.__dict__ directly, which respects insertion order

--- a/ballet/feature.py
+++ b/ballet/feature.py
@@ -290,8 +290,17 @@ class Feature:
             return False 
         if self.source != other.source:
             return False
-        if self.transformer != other.transformer:
-            return False
+        if isinstance(self.transformer, DelegatingRobustTransformer):
+            if self.transformer != other.transformer:
+                return False
+        elif isinstance(self.transformer, TransformerPipeline):
+            if not isinstance(other.transformer, TransformerPipeline):
+                return False
+            if len(self.transformer.steps) != len(other.transformer.steps):
+                return False
+            for i in range(self.transformer.steps):
+                if self.transformer.steps[i] != other.transformer.steps[i]:
+                    return False
         if self.options != other.options:
             return False 
 

--- a/tests/eng/test_base.py
+++ b/tests/eng/test_base.py
@@ -39,6 +39,17 @@ class TestBase(unittest.TestCase):
 
         self.assertTrue(np.array_equal(data_trans, data_func))
 
+    def test_simple_function_transformer_eq(self):
+        def func(x): return x + 5
+        trans = ballet.eng.base.SimpleFunctionTransformer(func)
+
+        eq_trans = ballet.eng.base.SimpleFunctionTransformer(func)
+        self.assertEqual(trans, eq_trans)
+
+        ne_func = lambda x: 2 * x
+        ne_trans = ballet.eng.base.SimpleFunctionTransformer(ne_func)
+        self.assertNotEqual(trans, ne_trans)
+
     def test_grouped_function_transformer(self):
         df = pd.DataFrame(
             data={
@@ -65,3 +76,21 @@ class TestBase(unittest.TestCase):
         result = trans.transform(df)
         expected_result = df.pipe(func)
         pd.util.testing.assert_series_equal(result, expected_result)
+
+    def test_grouped_function_transformer_eq(self):
+        func = np.sum
+        trans = ballet.eng.base.GroupedFunctionTransformer(
+            func, groupby_kwargs={'level': 'country'})
+        
+        eq_trans = ballet.eng.base.GroupedFunctionTransformer(
+            func, groupby_kwargs={'level': 'country'})
+        self.assertEqual(trans, eq_trans)
+
+        ne_func = np.max
+        ne_trans_func = ballet.eng.base.GroupedFunctionTransformer(
+            ne_func, groupby_kwargs={'level': 'country'})
+        self.assertNotEqual(trans, ne_trans_func)
+
+        ne_trans_groupby = ballet.eng.base.GroupedFunctionTransformer(
+            func, groupby_kwargs={'level': 'city'})
+        self.assertNotEqual(trans, ne_trans_groupby)

--- a/tests/eng/test_ts.py
+++ b/tests/eng/test_ts.py
@@ -40,6 +40,22 @@ class TestTimeSeriesTransformers(
 
         self.assertFrameEqual(result, expected_result)
 
+    def test_single_lagger_eq(self):
+        trans = ballet.eng.ts.SingleLagger(
+            1, groupby_kwargs={'level': 'city'})
+
+        eq_trans = ballet.eng.ts.SingleLagger(
+            1, groupby_kwargs={'level': 'city'})
+        self.assertEqual(trans, eq_trans)
+
+        ne_trans_lag = ballet.eng.ts.SingleLagger(
+            2, groupby_kwargs={'level': 'city'})
+        self.assertNotEqual(trans, ne_trans_lag, 'Expected lags to be not equal')
+
+        ne_trans_group = ballet.eng.ts.SingleLagger(
+            1, groupby_kwargs={'level': 'town'})
+        self.assertNotEqual(trans, ne_trans_group, 'Expected groupbys to be not equal')
+
     @unittest.expectedFailure
     def test_multi_lagger(self):
         # TODO


### PR DESCRIPTION
Implements feature equality, as well as equality for all transformers in ballet.eng and for the ballet transformer pipeline.

- note: does not work on features that use sklearn's transformers. Looking into ways that we might be able to do this