### PR TITLE
Implement CLI

### DIFF
--- a/ballet/cli.py
+++ b/ballet/cli.py
@@ -1,0 +1,20 @@
+import click
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+def quickstart():
+    """Generate a brand-new ballet project"""
+    import ballet.quickstart
+    ballet.quickstart.main()
+
+
+@cli.command('update-project-template')
+def update_project_template():
+    """Update an existing ballet project from the upstream template"""
+    import ballet.update
+    ballet.update.main()

--- a/ballet/quickstart.py
+++ b/ballet/quickstart.py
@@ -24,5 +24,4 @@ def generate_project(**kwargs):
 
 
 def main():
-    """Entry point for ballet-quickstart command line tool"""
     return generate_project()

--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,7 @@ setup(
     description='Core functionality for lightweight, collaborative data science projects',
     entry_points = {
         'console_scripts': [
-            'ballet-quickstart=ballet.quickstart:main',
-            'ballet-update-template=ballet.update:main',
+            'ballet=ballet.cli:cli',
         ],
     },
     extras_require={


### PR DESCRIPTION
Implements a project-wide CLI with subcommands for different functionality.

Example usage:
```shell
pip install ballet
ballet --help
ballet quickstart
ballet update-project-template
```