### PR TITLE
Fix git bad name error

### DIFF
--- a/ballet/util/__init__.py
+++ b/ballet/util/__init__.py
@@ -116,3 +116,10 @@ class DeepcopyMixin:
         for k, v in self.__dict__.items():
             setattr(result, k, deepcopy(v, memo))
         return result
+
+
+def one_or_raise(l):
+    if len(l) == 1:
+        return l[0]
+    else:
+        raise ValueError('Expected exactly 1 element')

--- a/ballet/util/ci.py
+++ b/ballet/util/ci.py
@@ -4,7 +4,8 @@ import git
 from funcy import constantly, ignore, post_processing
 
 from ballet.exc import UnexpectedTravisEnvironmentError
-from ballet.util.git import PullRequestBuildDiffer
+from ballet.util.git import (
+    get_diff_endpoints_from_commit_range, PullRequestBuildDiffer)
 from ballet.util.log import logger
 
 
@@ -89,8 +90,9 @@ class TravisPullRequestBuildDiffer(PullRequestBuildDiffer):
                 'TRAVIS_PULL_REQUEST {tpr!r} did not match expected {pr!r}'
                 .format(tpr=travis_pr_num, pr=self.pr_num))
 
-    def _get_diff_str(self):
-        return get_travis_env_or_fail('TRAVIS_COMMIT_RANGE')
+    def _get_diff_endpoints(self):
+        commit_range = get_travis_env_or_fail('TRAVIS_COMMIT_RANGE')
+        return get_diff_endpoints_from_commit_range(self.repo, commit_range)
 
     def _detect_repo(self):
         build_dir = get_travis_env_or_fail('TRAVIS_BUILD_DIR')

--- a/ballet/util/ci.py
+++ b/ballet/util/ci.py
@@ -5,7 +5,7 @@ from funcy import constantly, ignore, post_processing
 
 from ballet.exc import UnexpectedTravisEnvironmentError
 from ballet.util.git import (
-    get_diff_endpoints_from_commit_range, PullRequestBuildDiffer)
+    PullRequestBuildDiffer, get_diff_endpoints_from_commit_range)
 from ballet.util.log import logger
 
 

--- a/ballet/util/git.py
+++ b/ballet/util/git.py
@@ -7,7 +7,6 @@ from funcy import collecting, ignore, re_find, re_test
 from ballet.compat import pathlib, safepath
 from ballet.util import one_or_raise
 
-
 FILE_CHANGES_COMMIT_RANGE = '{a}...{b}'
 REV_REGEX = r'[a-zA-Z0-9_/^@{}-]+'
 COMMIT_RANGE_REGEX = re.compile(

--- a/ballet/util/git.py
+++ b/ballet/util/git.py
@@ -7,6 +7,7 @@ from funcy import collecting, ignore, re_find, re_test
 from ballet.compat import pathlib, safepath
 from ballet.util import one_or_raise
 
+
 FILE_CHANGES_COMMIT_RANGE = '{a}...{b}'
 REV_REGEX = r'[a-zA-Z0-9_/^@{}-]+'
 COMMIT_RANGE_REGEX = re.compile(
@@ -63,20 +64,34 @@ def make_commit_range(a, b):
 
 
 def get_diff_endpoints_from_commit_range(repo, commit_range):
-    """Get file changes via a commit range
+    """Get endpoints of a diff given a commit range
 
-    For details on specifying revisions, see `git help revisions`.
+    The resulting endpoints can be diffed directly::
+
+        a, b = get_diff_endpoints_from_commit_range(repo, commit_range)
+        a.diff(b)
+
+    For details on specifying git diffs, see ``git diff --help``.
+    For details on specifying revisions, see ``git help revisions``.
 
     Args:
         repo (git.Repo): Repo object initialized with project root
-        diff_str (str): diff string identifying range of diff as would be
-            interpreted by ``git diff`` command. Unfortunately only patterns of
-            the form ``a..b`` and ``a...b`` are accepted. For more details on
-            the difference between these two forms,
-            see https://stackoverflow.com/q/7251477.
+        commit_range (str): commit range as would be interpreted by ``git
+            diff`` command. Unfortunately only patterns of the form ``a..b``
+            and ``a...b`` are accepted. Note that the latter pattern finds the
+            merge-base of a and b and uses it as the starting point for the
+            diff.
 
     Returns:
-        List[git.diff.Diff]: changes between revisions
+        Tuple[git.Commit, git.Commit]: starting commit, ending commit (
+            inclusive)
+
+    Raises:
+        ValueError: commit_range is empty or ill-formed
+
+    See also:
+
+        <https://stackoverflow.com/q/7251477>
     """
     if not commit_range:
         raise ValueError('commit_range cannot be empty')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -19,7 +19,7 @@ from ballet.compat import pathlib, safepath
 from ballet.util.ci import (
     TravisPullRequestBuildDiffer, get_travis_pr_num, is_travis_pr)
 from ballet.util.git import (
-    make_commit_range, get_pull_request_outcomes, get_pull_requests)
+    get_pull_request_outcomes, get_pull_requests, make_commit_range)
 from ballet.util.mod import (  # noqa F401
     import_module_at_path, import_module_from_modname,
     import_module_from_relpath, modname_to_relpath, relpath_to_modname)

--- a/tests/util.py
+++ b/tests/util.py
@@ -63,7 +63,7 @@ class FragileTransformerPipeline(TransformerPipeline):
 
 
 def make_mock_commit(repo, kind='A', path=None, content=None):
-    '''Commits one file to repo'''
+    """Commits one file to repo"""
     if not path:
         path = 'file{}'.format(random.randint(0, 999))
 
@@ -92,7 +92,7 @@ def make_mock_commit(repo, kind='A', path=None, content=None):
 
 
 def make_mock_commits(repo, n=10, filename='file{i}.py'):
-    '''Create n sequential files/commits'''
+    """Create n sequential files/commits"""
     if '{i}' not in filename:
         raise ValueError
 
@@ -112,7 +112,7 @@ def set_ci_git_config_variables(repo):
 
 @contextmanager
 def mock_repo():
-    '''Create a new repo'''
+    """Create a new repo"""
     with tempfile.TemporaryDirectory() as tmpdir:
         dir = pathlib.Path(tmpdir)
         repo = git.Repo.init(str(dir))

--- a/tests/validation/test_project_structure.py
+++ b/tests/validation/test_project_structure.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 from unittest.mock import patch
 
 from ballet.util.ci import TravisPullRequestBuildDiffer
-from ballet.util.git import get_diff_str_from_commits
+from ballet.util.git import make_commit_range
 from ballet.validation.project_structure import ChangeCollector
 
 from ..util import make_mock_commits, mock_repo
@@ -57,7 +57,7 @@ class ChangeCollectorTest(_CommonSetup, unittest.TestCase):
         with mock_repo() as repo:
             commits = make_mock_commits(repo, n=n, filename=filename)
             contrib_module_path = None
-            commit_range = get_diff_str_from_commits(
+            commit_range = make_commit_range(
                 commits[0], commits[-1])
 
             travis_env_vars = {

--- a/tests/validation/util.py
+++ b/tests/validation/util.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 from funcy import contextmanager
 
-from ballet.util.git import get_diff_str_from_commits
+from ballet.util.git import make_commit_range
 from ballet.validation.project_structure import (
     ChangeCollector, FeatureApiValidator, FileChangeValidator)
 
@@ -71,7 +71,7 @@ def mock_file_change_validator(
     with mock_project(path_content) as repo:
         travis_build_dir = repo.working_tree_dir
         travis_pull_request = str(pr_num)
-        travis_commit_range = get_diff_str_from_commits(
+        travis_commit_range = '{}...{}'.format(
             repo.head.commit.parents[0], repo.head.commit)
 
         travis_env_vars = {
@@ -97,7 +97,7 @@ def mock_feature_api_validator(
     with mock_project(path_content) as repo:
         travis_build_dir = repo.working_tree_dir
         travis_pull_request = str(pr_num)
-        travis_commit_range = get_diff_str_from_commits(
+        travis_commit_range = make_commit_range(
             repo.head.commit.parents[0], repo.head.commit)
 
         travis_env_vars = {


### PR DESCRIPTION
The TRAVIS_COMMIT_RANGE variable set for PRs seems to either be `a..b` or `a...b` where `a` and `b` are hexshas, depending on the properties of the merge. Both types of commit ranges should be detected properly by the differ.

Closes #30 