### PR TITLE
Mask fix

### DIFF
--- a/ballet/validation/entropy.py
+++ b/ballet/validation/entropy.py
@@ -25,6 +25,7 @@ def calculate_disc_entropy(X):
         float: A floating-point number representing the dataset entropy.
 
     """
+    X = asarray2d(X)
     n_samples, _ = X.shape
     _, counts = np.unique(X, axis=0, return_counts=True)
     empirical_p = counts * 1.0 / n_samples
@@ -68,6 +69,7 @@ def estimate_cont_entropy(X, epsilon=None):
            of a Random Vector:, Probl. Peredachi Inf., 23:2 (1987), 9-16
 
     """
+    X = asarray2d(X)
     n_samples, n_features = X.shape
     if n_samples <= 1:
         return 0
@@ -161,6 +163,7 @@ def estimate_entropy(X, epsilon=None):
            of a Random Vector:, Probl. Peredachi Inf., 23:2 (1987), 9-16
 
     """
+    X = asarray2d(X)
     n_samples, n_features = X.shape
     if n_features < 1:
         return 0

--- a/ballet/validation/entropy.py
+++ b/ballet/validation/entropy.py
@@ -19,7 +19,8 @@ def calculate_disc_entropy(X):
     take datasets of mixed discrete and continuous functions.
 
     Args:
-        X (array-like): An array with shape (n_samples, n_features)
+        X (array-like): An array-like (np arr, pandas df, etc.) with shape
+            (n_samples, n_features) or (n_samples)
 
     Returns:
         float: A floating-point number representing the dataset entropy.
@@ -49,7 +50,8 @@ def estimate_cont_entropy(X, epsilon=None):
     take datasets of mixed discrete and continuous functions.
 
     Args:
-        X (array-like): An array with shape (n_samples, n_features)
+        X (array-like): An array-like (np arr, pandas df, etc.) with shape
+            (n_samples, n_features) or (n_samples)
         epsilon (array-like): An array with shape (n_samples, 1) that is
             the epsilon used in Kraskov Estimator. Represents the chebyshev
             distance from an element to its k-th nearest neighbor in the full
@@ -141,7 +143,8 @@ def estimate_entropy(X, epsilon=None):
     in the same row as a discrete column with value x in the original dataset.
 
     Args:
-        X (array-like): An array with shape (n_samples, n_features)
+        X (array-like): An array-like (np arr, pandas df, etc.) with shape
+            (n_samples, n_features) or (n_samples)
         epsilon (array-like): An array with shape (n_samples, 1) that is
             the epsilon used in Kraskov Estimator. Represents the chebyshev
             distance from an element to its k-th nearest neighbor in the full

--- a/ballet/validation/entropy.py
+++ b/ballet/validation/entropy.py
@@ -182,12 +182,12 @@ def estimate_entropy(X, epsilon=None):
 
     # $\sum_{x \in d} p(x) \times H(c(x))$
     for i in range(counts.size):
-        unique_mask = disc_features == uniques[i]
-        selected_cont_samples = cont_features[unique_mask.ravel(), :]
+        unique_mask = np.all(disc_features == uniques[i], axis=1)
+        selected_cont_samples = cont_features[unique_mask, :]
         if epsilon is None:
             selected_epsilon = None
         else:
-            selected_epsilon = epsilon[unique_mask]
+            selected_epsilon = epsilon[unique_mask, :]
         conditional_cont_entropy = estimate_cont_entropy(
             selected_cont_samples, selected_epsilon)
         entropy += empirical_p[i] * conditional_cont_entropy

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -423,12 +423,12 @@ class CiTest(unittest.TestCase):
                 'TRAVIS_PULL_REQUEST': 'false',
                 'TRAVIS_PULL_REQUEST_BRANCH': '',
                 'TRAVIS_BRANCH': 'master',
-              }, 'master'),
+            }, 'master'),
             ({
                 'TRAVIS_PULL_REQUEST': 'false',
                 'TRAVIS_PULL_REQUEST_BRANCH': '',
                 'TRAVIS_BRANCH': 'foo',
-              }, 'foo'),
+            }, 'foo'),
             ({
                 'TRAVIS_PULL_REQUEST': '1',
                 'TRAVIS_PULL_REQUEST_BRANCH': 'foo',

--- a/tests/validation/test_entropy.py
+++ b/tests/validation/test_entropy.py
@@ -40,6 +40,34 @@ class EntropyTest(unittest.TestCase):
             diff_val_h,
             msg='Expected entropy in x ~ Ber(0.5)')
 
+    def test_entropy_cont_disc_heuristics(self):
+        arange_disc_arr = np.arange(50)
+        arange_cont_arr = np.arange(50) + 0.5
+
+        disc_h = estimate_entropy(arange_disc_arr)
+        cont_h = estimate_entropy(arange_cont_arr)
+        self.assertNotEqual(
+            disc_h,
+            cont_h,
+            msg='Expected continuous and discrete columns to be handled differently')
+
+    def test_entropy_multiple_disc(self):
+        same_val_arr_zero = np.zeros((50, 1))
+        same_val_arr_ones = np.ones((50, 1))
+        # The 0.5 forces float => classified as continuous
+        cont_val_arange = np.arange(50) + 0.5
+        all_disc_arr = np.concatenate(
+            (same_val_arr_ones, same_val_arr_zero), axis=1)
+        mixed_val_arr = np.concatenate(
+            (all_disc_arr, cont_val_arange), axis=1)
+
+        all_disc_h = estimate_entropy(all_disc_arr)
+        mixed_h = estimate_entropy(mixed_val_arr)
+        self.assertGreater(
+            mixed_h,
+            all_disc_h,
+            meg='Expected adding continuous column increases entropy')
+
     def test_mi_uninformative(self):
         x = np.reshape(np.arange(1, 101), (100, 1))
         y = np.ones((100, 1))

--- a/tests/validation/test_entropy.py
+++ b/tests/validation/test_entropy.py
@@ -49,7 +49,7 @@ class EntropyTest(unittest.TestCase):
         self.assertNotEqual(
             disc_h,
             cont_h,
-            msg='Expected continuous and discrete columns to be handled differently')
+            msg='Expected cont, disc columns to be handled differently')
 
     def test_entropy_multiple_disc(self):
         same_val_arr_zero = np.zeros((50, 1))

--- a/tests/validation/test_entropy.py
+++ b/tests/validation/test_entropy.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy as np
 
+from ballet.util import asarray2d
 from ballet.validation.entropy import (
     calculate_disc_entropy, estimate_conditional_information, estimate_entropy,
     estimate_mutual_information)
@@ -41,8 +42,8 @@ class EntropyTest(unittest.TestCase):
             msg='Expected entropy in x ~ Ber(0.5)')
 
     def test_entropy_cont_disc_heuristics(self):
-        arange_disc_arr = np.arange(50)
-        arange_cont_arr = np.arange(50) + 0.5
+        arange_disc_arr = asarray2d(np.arange(50))
+        arange_cont_arr = asarray2d(np.arange(50) + 0.5)
 
         disc_h = estimate_entropy(arange_disc_arr)
         cont_h = estimate_entropy(arange_cont_arr)
@@ -55,7 +56,7 @@ class EntropyTest(unittest.TestCase):
         same_val_arr_zero = np.zeros((50, 1))
         same_val_arr_ones = np.ones((50, 1))
         # The 0.5 forces float => classified as continuous
-        cont_val_arange = np.arange(50) + 0.5
+        cont_val_arange = asarray2d(np.arange(50) + 0.5)
         all_disc_arr = np.concatenate(
             (same_val_arr_ones, same_val_arr_zero), axis=1)
         mixed_val_arr = np.concatenate(
@@ -66,7 +67,7 @@ class EntropyTest(unittest.TestCase):
         self.assertGreater(
             mixed_h,
             all_disc_h,
-            meg='Expected adding continuous column increases entropy')
+            msg='Expected adding continuous column increases entropy')
 
     def test_mi_uninformative(self):
         x = np.reshape(np.arange(1, 101), (100, 1))


### PR DESCRIPTION
Fixes issue #33 and adds a level of safety onto the entropy estimators such that they can take more objects (array, pandas df, 1d array, etc)

